### PR TITLE
Change key of results in configmap to include file extension

### DIFF
--- a/scapresults/scapresults.py
+++ b/scapresults/scapresults.py
@@ -131,7 +131,7 @@ def main():
 
         confmap = create_config_map(scan_instance,
                                     args.config_map,
-                                    "results",
+                                    "results.html",
                                     contents.decode(),
                                     compressed=compressed)
         print(confmap)


### PR DESCRIPTION
This changes the key from "results" to "results.html", this way, we can
use `oc extract` in order to fetch the results of the scan, and it'll be
downloaded as a file with the right file extension.